### PR TITLE
Add additional keyboard shortcuts to exit app

### DIFF
--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -6,6 +6,7 @@ import 'package:flutter_localizations/flutter_localizations.dart';
 import 'emoji/emoji_page.dart';
 import 'settings/cubit/settings_cubit.dart';
 import 'settings/settings_page.dart';
+import 'shortcuts/app_shortcuts.dart';
 import 'style/theme.dart';
 
 /// The base widget that configures the application.
@@ -68,9 +69,9 @@ class App extends StatelessWidget {
               builder: (BuildContext context) {
                 switch (routeSettings.name) {
                   case SettingsPage.routeName:
-                    return const SettingsPage();
+                    return AppShortcuts(child: const SettingsPage());
                   default:
-                    return const EmojiPage();
+                    return AppShortcuts(child: const EmojiPage());
                 }
               },
             );

--- a/lib/src/emoji/emoji_page.dart
+++ b/lib/src/emoji/emoji_page.dart
@@ -1,6 +1,3 @@
-import 'dart:developer';
-import 'dart:io';
-
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -40,7 +37,7 @@ class _EmojiPageState extends State<EmojiPage> {
   Widget build(BuildContext context) {
     return FocusScope(
       onKey: (FocusNode node, RawKeyEvent event) {
-        return handleShortcuts(event, searchBoxFocusNode);
+        return _redirectSearchKeys(event, searchBoxFocusNode);
       },
       child: Scaffold(
         appBar: AppBar(
@@ -71,13 +68,12 @@ class _EmojiPageState extends State<EmojiPage> {
     );
   }
 
-  /// Decides what to do when keystrokes are detected.
-  KeyEventResult handleShortcuts(
+  /// Automatically focuses the search field when the user types.
+  KeyEventResult _redirectSearchKeys(
     RawKeyEvent event,
     FocusNode searchBoxFocusNode,
   ) {
     const navigationKeys = <LogicalKeyboardKey>[
-      LogicalKeyboardKey.escape,
       LogicalKeyboardKey.tab,
       LogicalKeyboardKey.arrowUp,
       LogicalKeyboardKey.arrowDown,
@@ -98,17 +94,10 @@ class _EmojiPageState extends State<EmojiPage> {
     if (searchHasFocus && isNavigationKey) {
       gridViewFocusNode.requestFocus();
       gridViewFocusNode.nextFocus(); // Skip focus to first result item.
+      return KeyEventResult.handled;
     }
 
-    final isEscapeKey = event.isKeyPressed(LogicalKeyboardKey.escape);
-
-    // Exit app if user presses escape.
-    if (isEscapeKey) {
-      log('Escape pressed, exiting.');
-      exit(0);
-    } else {
-      return KeyEventResult.ignored;
-    }
+    return KeyEventResult.ignored;
   }
 
   @override
@@ -180,7 +169,7 @@ class EmojiGridView extends StatelessWidget {
     return Expanded(
       child: Scrollbar(
         controller: gridviewScrollController,
-        isAlwaysShown: true,
+        thumbVisibility: true,
         child: BlocListener<EmojiCubit, EmojiState>(
           listenWhen: (previous, current) =>
               previous.copiedEmoji != current.copiedEmoji,

--- a/lib/src/shortcuts/app_shortcuts.dart
+++ b/lib/src/shortcuts/app_shortcuts.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import 'shortcuts.dart';
+
+/// Shortcuts that are available everywhere in the app.
+///
+/// This widget is to be wrapped around the widget intended as a route.
+class AppShortcuts extends StatelessWidget {
+  final Widget child;
+
+  AppShortcuts({
+    Key? key,
+    required this.child,
+  }) : super(key: key);
+
+  final _shortcuts = <LogicalKeySet, Intent>{
+    LogicalKeySet(
+      LogicalKeyboardKey.escape,
+    ): const QuitIntent(),
+  };
+
+  final _actions = <Type, Action<Intent>>{
+    QuitIntent: QuitAction(),
+  };
+
+  @override
+  Widget build(BuildContext context) {
+    return Shortcuts(
+      manager: LoggingShortcutManager(),
+      shortcuts: _shortcuts,
+      child: Actions(
+        dispatcher: LoggingActionDispatcher(),
+        actions: _actions,
+        child: child,
+      ),
+    );
+  }
+}

--- a/lib/src/shortcuts/app_shortcuts.dart
+++ b/lib/src/shortcuts/app_shortcuts.dart
@@ -18,6 +18,14 @@ class AppShortcuts extends StatelessWidget {
     LogicalKeySet(
       LogicalKeyboardKey.escape,
     ): const QuitIntent(),
+    LogicalKeySet(
+      LogicalKeyboardKey.control,
+      LogicalKeyboardKey.keyQ,
+    ): const QuitIntent(),
+    LogicalKeySet(
+      LogicalKeyboardKey.control,
+      LogicalKeyboardKey.keyW,
+    ): const QuitIntent(),
   };
 
   final _actions = <Type, Action<Intent>>{

--- a/lib/src/shortcuts/shortcuts.dart
+++ b/lib/src/shortcuts/shortcuts.dart
@@ -1,0 +1,52 @@
+import 'dart:developer';
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+
+/// A ShortcutManager that logs all keys that it handles.
+class LoggingShortcutManager extends ShortcutManager {
+  @override
+  KeyEventResult handleKeypress(BuildContext context, RawKeyEvent event) {
+    final KeyEventResult result = super.handleKeypress(context, event);
+    if (result == KeyEventResult.handled) {
+      log('''Handled shortcut
+Shortcut: $event
+Context: $context
+      ''');
+    }
+    return result;
+  }
+}
+
+/// An ActionDispatcher that logs all the actions that it invokes.
+class LoggingActionDispatcher extends ActionDispatcher {
+  @override
+  Object? invokeAction(
+    covariant Action<Intent> action,
+    covariant Intent intent, [
+    BuildContext? context,
+  ]) {
+    log('''Action invoked:
+Action: $action($intent)
+From: $context
+    ''');
+    // log('Action invoked: $action($intent) from $context');
+    super.invokeAction(action, intent, context);
+
+    return null;
+  }
+}
+
+/// An intent that is bound to QuitAction in order to quit this application.
+class QuitIntent extends Intent {
+  const QuitIntent();
+}
+
+/// An action that is bound to QuitIntent in order to quit this application.
+class QuitAction extends Action<QuitIntent> {
+  @override
+  Object? invoke(QuitIntent intent) {
+    log('Quit requested, exiting.');
+    exit(0);
+  }
+}


### PR DESCRIPTION
Add proper shortcut handling, more extensible and reliable going forward.

Add Ctrl+Q & Ctrl+W shortcuts for quitting app

Ctrl+Q is a standard Linux shortcut for exiting an application.

Ctrl+W is muscle memory for closing tabs, so it works as well.