### PR TITLE
[Desktop/Web] Replace window title with the app name

### DIFF
--- a/linux/my_application.cc
+++ b/linux/my_application.cc
@@ -7,6 +7,8 @@
 
 #include "flutter/generated_plugin_registrant.h"
 
+const char *WINDOW_TITLE = "Feeling Finder";
+
 struct _MyApplication {
   GtkApplication parent_instance;
   char** dart_entrypoint_arguments;
@@ -40,20 +42,20 @@ static void my_application_activate(GApplication* application) {
   if (use_header_bar) {
     GtkHeaderBar* header_bar = GTK_HEADER_BAR(gtk_header_bar_new());
     gtk_widget_show(GTK_WIDGET(header_bar));
-    gtk_header_bar_set_title(header_bar, "feeling_finder");
+    gtk_header_bar_set_title(header_bar, WINDOW_TITLE);
     gtk_header_bar_set_show_close_button(header_bar, TRUE);
     gtk_window_set_titlebar(window, GTK_WIDGET(header_bar));
   } else {
-    gtk_window_set_title(window, "feeling_finder");
+    gtk_window_set_title(window, WINDOW_TITLE);
   }
 
   gtk_window_set_default_size(window, 620, 590);
-  
+
   /* --------------------------------- Custom --------------------------------- */
-  /// Hide window by default so we can manipulate size, frame, etc and 
+  /// Hide window by default so we can manipulate size, frame, etc and
   /// then show the window when we are ready.
   ///
-  /// `gtk_widget_realize` will create the window without showing it, 
+  /// `gtk_widget_realize` will create the window without showing it,
   /// then the Dart code can call `window_size.setWindowVisibility(visible: true);`.
   // gtk_widget_show(GTK_WIDGET(window));   <-- Previous implementation.
   gtk_widget_realize(GTK_WIDGET(window));

--- a/web/index.html
+++ b/web/index.html
@@ -29,7 +29,7 @@
   <!-- Favicon -->
   <link rel="icon" type="image/png" href="favicon.png"/>
 
-  <title>feeling_finder</title>
+  <title>Feeling Finder</title>
   <link rel="manifest" href="manifest.json">
 </head>
 <body>

--- a/windows/runner/Runner.rc
+++ b/windows/runner/Runner.rc
@@ -95,7 +95,7 @@ BEGIN
             VALUE "InternalName", "feeling_finder" "\0"
             VALUE "LegalCopyright", "Copyright (C) 2021 com.example. All rights reserved." "\0"
             VALUE "OriginalFilename", "feeling_finder.exe" "\0"
-            VALUE "ProductName", "feeling_finder" "\0"
+            VALUE "ProductName", "Feeling Finder" "\0"
             VALUE "ProductVersion", VERSION_AS_STRING "\0"
         END
     END

--- a/windows/runner/main.cpp
+++ b/windows/runner/main.cpp
@@ -5,6 +5,8 @@
 #include "flutter_window.h"
 #include "utils.h"
 
+const wchar_t *WINDOW_TITLE = L"Feeling Finder";
+
 int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
                       _In_ wchar_t *command_line, _In_ int show_command) {
   // Attach to console when present (e.g., 'flutter run') or create a
@@ -27,7 +29,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
   FlutterWindow window(project);
   Win32Window::Point origin(10, 10);
   Win32Window::Size size(620, 590);
-  if (!window.CreateAndShow(L"feeling_finder", origin, size)) {
+  if (!window.CreateAndShow(WINDOW_TITLE, origin, size)) {
     return EXIT_FAILURE;
   }
   window.SetQuitOnClose(true);


### PR DESCRIPTION
At this moment, in the window title you can see the package name (`feeling_finder`), not the app name (`Feeling Finder`). My PR fixes this for Linux, Windows and Web. 

Before:
![window title](https://user-images.githubusercontent.com/7840559/166471499-ad44ca5b-9ea8-4f32-9cb1-4c2272de9f84.png)

After:
![window title](https://user-images.githubusercontent.com/7840559/166471859-5fe29cce-a2c8-4bb8-b17f-30de89daac72.png)
