### PR TITLE
Fix category items alignment

### DIFF
--- a/lib/src/emoji/emoji_page.dart
+++ b/lib/src/emoji/emoji_page.dart
@@ -135,7 +135,10 @@ class CategoryListView extends StatelessWidget {
               } else {
                 return ListTile(
                   title: Center(
-                    child: Text(category.localizedName(context)),
+                    child: Text(
+                      category.localizedName(context),
+                      textAlign: TextAlign.center,
+                    ),
                   ),
                   selected: (state.category == category),
                   onTap: () {

--- a/lib/src/emoji/emoji_page.dart
+++ b/lib/src/emoji/emoji_page.dart
@@ -134,11 +134,9 @@ class CategoryListView extends StatelessWidget {
                 return const SizedBox();
               } else {
                 return ListTile(
-                  title: Center(
-                    child: Text(
-                      category.localizedName(context),
-                      textAlign: TextAlign.center,
-                    ),
+                  title: Text(
+                    category.localizedName(context),
+                    textAlign: TextAlign.center,
                   ),
                   selected: (state.category == category),
                   onTap: () {


### PR DESCRIPTION
I found that long localized text has start alignment and it looks ugly:

![2022-05-03 17-37-46](https://user-images.githubusercontent.com/7840559/166475651-26f67da3-d5c6-4634-8622-7c1fa8e53ca4.png)

This PR makes text align to center:

![2022-05-03 17-37-58](https://user-images.githubusercontent.com/7840559/166475850-80c2e356-f4ee-4e04-a1c0-6e1cbef488a6.png)

