### PR TITLE
fix: emojis appear differently on different platforms

### DIFF
--- a/lib/src/emoji/emoji_page.dart
+++ b/lib/src/emoji/emoji_page.dart
@@ -275,7 +275,7 @@ class _EmojiGridViewState extends State<EmojiGridView> {
               SnackBar(
                 content: Text(
                   '${state.copiedEmoji} copied to clipboard.',
-                  style: const TextStyle(
+                  style: TextStyle(
                     fontSize: 25,
                     fontFamily: emojiFont,
                   ),

--- a/lib/src/emoji/emoji_service.dart
+++ b/lib/src/emoji/emoji_service.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:helpers/helpers.dart';
 import 'package:unicode_emojis/unicode_emojis.dart' as ue;
 
 import 'emoji.dart';
@@ -56,6 +58,11 @@ Map<EmojiCategory, List<Emoji>> _buildEmojisFromUnicodePackage() {
         .where((emoji) => emoji.category == emojiCategory)
         .map((ue.Emoji emoji) => emoji.toEmoji())
         .toList();
+
+    if (defaultTargetPlatform.isWindows) {
+      // Windows only supports version 14.0 of the Unicode emoji set.
+      emojiList.removeWhere((e) => double.parse(e.unicodeVersion) > 14.0);
+    }
 
     emojiMap[emojiCategory.toEmojiCategory()] = emojiList;
   }

--- a/lib/src/emoji/styles.dart
+++ b/lib/src/emoji/styles.dart
@@ -1,3 +1,12 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:helpers/helpers.dart';
+
+final TextTheme emojiTextTheme = GoogleFonts.notoColorEmojiTextTheme();
+
 /// It is required to use the emoji font, otherwise emojis
 /// all appear as simple black and white glyphs.
-const emojiFont = 'Noto Color Emoji';
+final String? emojiFont = (defaultTargetPlatform.isWindows)
+    ? null
+    : emojiTextTheme.bodyMedium?.fontFamily ?? 'Noto Color Emoji';

--- a/lib/src/emoji/widgets/emoji_tile.dart
+++ b/lib/src/emoji/widgets/emoji_tile.dart
@@ -158,7 +158,7 @@ class _EmojiTileState extends State<EmojiTile> {
     if (widget.emoji.aliases.contains('custom')) {
       // Button to remove the custom emoji.
       items.add(
-        const PopupMenuItem(
+        PopupMenuItem(
           value: 'remove',
           child: Center(
             child: Text(
@@ -179,7 +179,7 @@ class _EmojiTileState extends State<EmojiTile> {
             child: Center(
               child: Text(
                 variant.emoji,
-                style: const TextStyle(
+                style: TextStyle(
                   fontSize: 35,
                   fontFamily: emojiFont,
                 ),


### PR DESCRIPTION
Include the Noto Color Emoji font in the package and use it to render
emojis on all platforms. This ensures that emojis appear the same on
all platforms, even if the user's system does not have the Noto Color
Emoji font installed.

Resolves #62 