### PR TITLE
feat: add deb build config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,10 +2,11 @@
 #                                    Custom                                    #
 # ---------------------------------------------------------------------------- #
 
+.fvm/
+
 # Flatpak
 .flatpak-builder/
 build-dir/
-
 
 # Freezed
 *.freezed.dart
@@ -15,6 +16,9 @@ build-dir/
 generated*
 Generated*
 *.mocks.dart
+
+# Packaging
+dist/
 
 # Test coverage
 lcov.info
@@ -48,7 +52,6 @@ lib/src/localization/gen/*
 #.vscode/
 
 # Flutter/Dart/Pub related
-.fvm/
 **/doc/api/
 **/ios/Flutter/.last_build_id
 .dart_tool/
@@ -58,7 +61,6 @@ lib/src/localization/gen/*
 .pub-cache/
 .pub/
 /build/
-/dist/
 
 # Web related
 lib/generated_plugin_registrant.dart

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ lcov.info
 #.vscode/
 
 # Flutter/Dart/Pub related
+.fvm/
 **/doc/api/
 **/ios/Flutter/.last_build_id
 .dart_tool/
@@ -56,6 +57,7 @@ lcov.info
 .pub-cache/
 .pub/
 /build/
+/dist/
 
 # Web related
 lib/generated_plugin_registrant.dart

--- a/linux/packaging/deb/make_config.yaml
+++ b/linux/packaging/deb/make_config.yaml
@@ -1,0 +1,37 @@
+display_name: Feeling Finder
+package_name: feeling-finder
+maintainer:
+  name: Merrit
+  email:
+priority: optional
+section: x11
+installed_size: 27859
+essential: false
+icon: assets/icons/codes.merritt.FeelingFinder.png
+
+#pre_dependencies:
+#  - libc6 (>= 2.31)
+
+dependencies:
+  - libkeybinder-3.0-0
+  - libappindicator3-1
+  - libayatana-appindicator3-1
+  - libayatana-ido3-0.4-0
+
+#postinstall_scripts:
+#  - echo "Feeling Finder Installed!"
+#postuninstall_scripts:
+#  - echo "Sorry to see you go 😞"
+
+keywords:
+  - Emojis
+  - Ease of Use
+
+generic_name: A fast and beautiful app to help convey emotion in text communication.
+
+categories:
+  - GTK
+  - Utility
+  - Amusement
+
+startup_notify: true

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,6 +6,8 @@ publish_to: "none"
 
 version: 1.0.0+15
 
+homepage: https://github.com/Merrit/feeling_finder
+
 environment:
   sdk: ">=3.0.0 <4.0.0"
 


### PR DESCRIPTION
Steps:

Install flutter distributor

```
dart pub global activate flutter_distributor
``` 
Configure .pub-cache on PATH

```
echo 'export PATH="$PATH:$HOME/.pub-cache/bin"' >> ~/.bashrc
``` 

Generate the .deb package

```
flutter_distributor package --platform linux --targets deb
``` 

### Observation: The homepage information for the debian package is taken from the pubspec file:

https://github.com/leanflutter/flutter_distributor/blob/8e55decfeae942bdf631f2b2b61912b3a25dc39a/packages/flutter_app_packager/lib/src/makers/deb/make_deb_config.dart#LL278C4-L278C4

### Both libappindicator3-1 and libayatana-appindicator3-1 are included due to Ubuntu 20 / Debian 10 packages having a different structure.
